### PR TITLE
Content-type explicitly set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ php:
 services:
   - docker
 before_script:
-  - docker pull elasticsearch:6.2.2
+  - docker pull docker.elastic.co/elasticsearch/elasticsearch:6.2.2
   - docker run -d -p 127.0.0.1:9200:9200 -v "$(pwd)/elasticsearch.yml":/usr/share/elasticsearch/config/elasticsearch.yml elasticsearch
   - sleep 15

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ php:
 services:
   - docker
 before_script:
-  - docker pull elasticsearch:2:3
+  - docker pull elasticsearch:2.3
   - docker run -d -p 127.0.0.1:9200:9200 -v "$(pwd)/elasticsearch.yml":/usr/share/elasticsearch/config/elasticsearch.yml elasticsearch
   - sleep 15

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ php:
 services:
   - docker
 before_script:
-  - docker pull docker.elastic.co/elasticsearch/elasticsearch:6.2.2
+  - docker pull elasticsearch:2:3
   - docker run -d -p 127.0.0.1:9200:9200 -v "$(pwd)/elasticsearch.yml":/usr/share/elasticsearch/config/elasticsearch.yml elasticsearch
   - sleep 15

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 php:
-  - 5.5
+  - 7.0
 services:
   - docker
 before_script:
-  - docker pull elasticsearch:2.3
+  - docker pull elasticsearch:6.2.2
   - docker run -d -p 127.0.0.1:9200:9200 -v "$(pwd)/elasticsearch.yml":/usr/share/elasticsearch/config/elasticsearch.yml elasticsearch
   - sleep 15

--- a/src/elasticsearch/Indexer.php
+++ b/src/elasticsearch/Indexer.php
@@ -385,6 +385,10 @@ class Indexer
 			$settings['timeout'] = Config::option('server_timeout_read') ?: 1;
 		}
 
+		// Required as of ES 6.0, content sniffing no longer enough:
+		// - https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests
+		$settings['connections']['config']['headers'] = ['Content-Type' => 'application/json'];
+
 		// Allow custom settings to be passed by users who want to.
 		$settings = apply_filters('indexer_client_settings', $settings);
 

--- a/tests/unit-tests/elasticsearch/BaseTestCase.php
+++ b/tests/unit-tests/elasticsearch/BaseTestCase.php
@@ -1,7 +1,7 @@
 <?php
 namespace elasticsearch;
 
-abstract class BaseTestCase extends \PHPUnit_Framework_TestCase{
+abstract class BaseTestCase extends \PHPUnit\Framework\TestCase{
 	protected function setUp()
 	{
 		global $wp_query, $blog_id, $wpdb;


### PR DESCRIPTION
Explicitly set content type when creating ES connection.

ES behaviour before 5 was to sniff content type from the request. This became optional in 5, with the expected behaviour being explicit statement of the content type. As of version 6, sniffing is disabled, with an explicit content type required (https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests).

The plugin runs into problems here, as it by default posts a form. This triggers an error from ES -
 `Content-Type header [application/x-www-form-urlencoded] is not supported`.

Explicitly add the content type header to avoid this.